### PR TITLE
Develop build 0.1.6

### DIFF
--- a/nonja/builder.py
+++ b/nonja/builder.py
@@ -1,14 +1,14 @@
 import json
-import re
 import sys
 import importlib
 import lxml.etree as et
-from os import path, walk, getcwd, makedirs, system
+from os import path, walk, getcwd, makedirs, system, unlink
 from jinja2 import Environment, FileSystemLoader
-from lxml.builder import E, ElementMaker
+from lxml.builder import E
 from datetime import datetime
 from json import load
-from uuid import uuid4
+import shutil
+from PIL import Image
 
 from nonja.style import bold, reset
 import nonja.console as console
@@ -18,55 +18,60 @@ import nonja.functions as functions
 
 def _run_package_manager():
     # TODO: Feels like there might be a better manner of handling invoking the package manager.
-    npm_lock_path = './package-lock.json'
-    yarn_lock_path = './yarn.lock'
+    npm_lock_path = "./package-lock.json"
+    yarn_lock_path = "./yarn.lock"
 
     if path.exists(npm_lock_path):
-        system('npm run sass:build')
+        system("npm run sass:build")
     elif path.exists(yarn_lock_path):
-        system('yarn sass:build')
+        system("yarn sass:build")
     elif not path.exists(npm_lock_path) and not path.exists(yarn_lock_path):
         console.error("Package lock files could not be found, ignoring.")
 
 
 def rebuild_project():
     # TODO: Need to use file removal methods from Python instead of this.
-    build_folder_path = path.join('.', 'build')
+    build_folder_path = path.join(".", "build")
     system(f"rm -rf {build_folder_path}")
     build_project()
 
 
-def build_project():
+def build_project(**args):
     project_config = _get_project_config()
     _run_package_manager()
 
-    content_folder_path = path.join(getcwd(), 'src/content')
+    include_assets_flag = "include-assets"
+
+    if include_assets_flag in args and args.get(include_assets_flag):
+        _migrate_assets()
+
+    content_folder_path = path.join(getcwd(), "src/content")
     if not path.exists(content_folder_path):
         console.error(f"Content source path {bold}{content_folder_path}{reset} could not be found")
         exit(0)
     else:
         console.info(f"Processing content from folder {bold}{content_folder_path}{reset}")
 
-    x_filter_mod_name = path.join(getcwd(), 'filters.py')
+    x_filter_mod_name = path.join(getcwd(), "filters.py")
     if path.exists(x_filter_mod_name):
         sys.path.insert(0, getcwd())
 
-    console.info('Setting up Jinja environment.')
+    console.info("Setting up Jinja environment.")
     env = Environment(
         loader=FileSystemLoader(content_folder_path),
         autoescape=False
     )
 
     env.filters = {
-        'date': filters.datetime_format,
-        'encode': filters.encode,
+        "date": filters.datetime_format,
+        "encode": filters.encode,
     }
 
     try:
-        x_filter_mod_name = 'filters'
+        x_filter_mod_name = "filters"
         x_filter_mod = importlib.import_module(x_filter_mod_name)
         for f in dir(x_filter_mod):
-            if not f.startswith('__') and not f.startswith('_'):
+            if not f.startswith("__") and not f.startswith("_"):
                 env.filters[f] = getattr(x_filter_mod, f)
     except ImportError:
         pass
@@ -78,18 +83,18 @@ def build_project():
         markdown=functions.import_markdown,
     )
 
-    source_folder_path = 'src/content'
-    build_target_path = 'build'
+    source_folder_path = "src/content"
+    build_target_path = "build"
 
     build_tally = 0
 
     for cwd, _, files in walk(content_folder_path):
         for file in files:
-            if file.startswith('_') or not file.endswith('.j2'):
+            if file.startswith("_") or not file.endswith(".j2"):
                 continue
 
-            content_file_path = path.join(cwd.replace(content_folder_path, ''), file)
-            if content_file_path.startswith('/'):
+            content_file_path = path.join(cwd.replace(content_folder_path, ""), file)
+            if content_file_path.startswith("/"):
                 content_file_path = content_file_path[1:]
 
             template = env.get_template(content_file_path)
@@ -101,7 +106,7 @@ def build_project():
             if not path.exists(output_folder_path):
                 makedirs(output_folder_path, exist_ok=True)
 
-            with open(output_file_path, 'wb') as output_file:
+            with open(output_file_path, "wb") as output_file:
                 output_file.write(result.encode())
                 build_tally += 1
 
@@ -112,37 +117,37 @@ def build_project():
 
 
 def _write_sitemap():
-    package_file_path = path.join(getcwd(), 'package.json')
-    with open(package_file_path, 'rb') as package_file:
+    package_file_path = path.join(getcwd(), "package.json")
+    with open(package_file_path, "rb") as package_file:
         package_content = json.load(package_file)
 
-    project_config = package_content.get('nonjaProject')
-    project_base_url = project_config.get('domain')
+    project_config = package_content.get("nonjaProject")
+    project_base_url = project_config.get("domain")
 
-    build_folder_path = path.join(getcwd(), 'build')
+    build_folder_path = path.join(getcwd(), "build")
     sitemap_node_count = 0
     sitemap_content = E.sitemap(
         {
-            'xmlns': 'http://www.sitemaps.org/schemas/sitemap/0.9'
+            "xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9"
         }
     )
     for cwd, _, files in walk(build_folder_path):
         for filename in files:
-            if not filename.endswith('.html'):
+            if not filename.endswith(".html"):
                 continue
 
             file_path = (path.join(cwd, filename)
-                         .replace(path.join(getcwd(), 'build'), project_base_url)
-                         .replace('index.html', ''))
+                         .replace(path.join(getcwd(), "build"), project_base_url)
+                         .replace("index.html", ""))
 
             sitemap_content.append(E.url(
                 E.loc(file_path),
-                E.lastmod(datetime.now().strftime('%Y-%m-%d'))
+                E.lastmod(datetime.now().strftime("%Y-%m-%d"))
             ))
             sitemap_node_count += 1
 
-    sitemap_file_path = path.join(getcwd(), 'build/sitemap.xml')
-    with open(sitemap_file_path, 'wb') as sitemap_file:
+    sitemap_file_path = path.join(getcwd(), "build/sitemap.xml")
+    with open(sitemap_file_path, "wb") as sitemap_file:
         sitemap_file.write(et.tostring(sitemap_content, pretty_print=True))
 
     console.info(f"Wrote site map data file {bold}{sitemap_file_path}{reset} for {sitemap_node_count} url nodes")
@@ -150,22 +155,84 @@ def _write_sitemap():
 
 def _write_robots_file():
     # Create robots.txt
-    robots_file_content = '''# www.robotstxt.org/
+    robots_file_content = """# www.robotstxt.org/
 
 # Allow crawling for all content
 User-agent: *
 Disallow:
-'''
-    robots_file_path = './build/robots.txt'
-    with open(robots_file_path, 'wb') as robots_file:
+"""
+    robots_file_path = "./build/robots.txt"
+    with open(robots_file_path, "wb") as robots_file:
         robots_file.write(robots_file_content.encode())
 
     console.info(f"Wrote {bold}robots.txt{reset} for the project.")
 
 
 def _get_project_config():
-    package_file_path = path.join(getcwd(), 'package.json')
-    with open(package_file_path, 'rb') as package_file:
+    package_file_path = path.join(getcwd(), "package.json")
+    with open(package_file_path, "rb") as package_file:
         package_content = load(package_file)
 
-    return package_content.get('nonjaProject', None)
+    return package_content.get("nonjaProject", None)
+
+def _migrate_assets():
+    image_assets_path = "./src/images"
+    image_assets_folder = path.join(getcwd(), image_assets_path)
+    output_image_path = "./build/assets/images"
+    output_image_folder = path.join(getcwd(), output_image_path)
+
+    drawings_assets_path = "./src/drawings"
+    drawings_assets_folder = path.join(getcwd(), drawings_assets_path)
+    output_drawings_path = "./build/assets/drawings"
+    output_drawings_folder = path.join(getcwd(), output_drawings_path)
+
+    jpeg_ext = ".jpg"
+    png_ext = ".png"
+    webp_ext = ".webp"
+    svg_ext = ".svg"
+
+    image_conv_count = 0
+    image_move_count = 0
+
+    # Converting all raster assets to WEBP
+    for root, _, files in walk(image_assets_folder):
+        for file in files:
+            asset_path = path.join(root, file)
+
+            if file.endswith((jpeg_ext, png_ext)):
+                asset_file_name, _ = path.splitext(file)
+                converted_file_name = asset_file_name + webp_ext
+                converted_output_path = path.join(output_image_folder, converted_file_name)
+                
+                asset_image = Image.open(asset_path).convert("RGB")
+                asset_image.save(converted_output_path, "webp", quality=80)
+                image_conv_count += 1
+            elif file.endswith(webp_ext):
+                migrate_output_path = path.join(output_image_folder, file)
+
+                if path.exists(migrate_output_path):
+                    unlink(migrate_output_path)
+
+                shutil.copy2(asset_path, migrate_output_path)
+                image_move_count += 1
+                
+            else:
+                continue
+
+    # TODO: Need to come up with ways to optimize SVG drawings
+    if not path.exists(output_drawings_folder):
+        makedirs(output_drawings_folder, exist_ok=True)
+
+    for root, _, files in walk(drawings_assets_folder):
+        for file in files:
+            if file.endswith(svg_ext):
+                drawing_path = path.join(root, file)
+                target_drawing_path = path.join(output_drawings_folder, file)
+
+                if path.exists(target_drawing_path):
+                    unlink(target_drawing_path)
+                
+                shutil.copy(drawing_path, target_drawing_path)
+                image_move_count += 1
+
+    console.info(f"Asset processing: {image_conv_count} assets converted, {image_move_count} assets added")

--- a/nonja/builder.py
+++ b/nonja/builder.py
@@ -79,13 +79,13 @@ def build_project():
     )
 
     source_folder_path = 'src/content'
-    build_target_path = 'build' if project_config.get('projectType', 'web') == 'web' else 'build/content'
+    build_target_path = 'build'
 
     build_tally = 0
 
     for cwd, _, files in walk(content_folder_path):
         for file in files:
-            if file.startswith('_') or not file.endswith('.html'):
+            if file.startswith('_') or not file.endswith('.j2'):
                 continue
 
             content_file_path = path.join(cwd.replace(content_folder_path, ''), file)
@@ -101,22 +101,14 @@ def build_project():
             if not path.exists(output_folder_path):
                 makedirs(output_folder_path, exist_ok=True)
 
-            if project_config.get('projectType', 'web') == 'book':
-                output_file_path = output_file_path.replace('.html', '.xhtml')
-
             with open(output_file_path, 'wb') as output_file:
                 output_file.write(result.encode())
                 build_tally += 1
 
     console.info(f"Wrote {bold}{build_tally}{reset} pages for the project.")
 
-    if project_config.get('projectType', 'web') == 'web':
-        _write_robots_file()
-        _write_sitemap()
-    else:
-        _write_container()
-        _write_opf_package()
-        _write_mimetype()
+    _write_robots_file()
+    _write_sitemap()
 
 
 def _write_sitemap():
@@ -177,122 +169,3 @@ def _get_project_config():
         package_content = load(package_file)
 
     return package_content.get('nonjaProject', None)
-
-
-def _write_container():
-    container_content = E.container({
-        'xmlns': 'urn:oasis:names:tc:opendocument:xmlns:container',
-        'version': '1.0'
-    },
-        E.rootfiles(
-            E.rootfile({'full-path': 'content/source.opf', 'media-type': 'application/oebps-package+xml'})
-        )
-    )
-
-    container_file_path = path.join(getcwd(), 'build/META-INF/container.xml')
-    if not path.exists(path.dirname(container_file_path)):
-        makedirs(path.dirname(container_file_path), exist_ok=True)
-
-    with open(container_file_path, 'wb') as container_file:
-        container_file.write(et.tostring(container_content))
-
-    console.info(f"Wrote container file for OEBPS pub format {bold}{container_file_path}{reset}.")
-
-
-def _write_opf_package():
-    config = _get_project_config()
-    unique_id = str(uuid4())
-    build_path = path.join(getcwd(), 'build/content')
-
-    items = []
-    spines = []
-
-    for cwd, _, files in walk(build_path):
-        files.sort()
-        for filename in files:
-            if filename.endswith('.opf'):
-                continue
-
-            item_identifier = f"content-{uuid4()}"
-            item_data = {
-                'id': item_identifier,
-                'href': path.join(cwd, filename).replace(f"{build_path}/", '')
-            }
-
-            if filename.endswith('.xhtml'):
-                item_data['media-type'] = 'application/xhtml+xml'
-                if filename == 'nav.xhtml':
-                    item_data['properties'] = 'nav'
-                    spines.insert(0, E.itemref({'idref': item_identifier}))
-                else:
-                    spines.append(E.itemref({'idref': item_identifier}))
-            elif filename.endswith('.css'):
-                item_data['media-type'] = 'text/css'
-            elif filename.endswith('.svg'):
-                item_data['media-type'] = 'image/svg+xml'
-            elif filename.endswith('.webp'):
-                item_data['media-type'] = 'image/webp'
-            elif filename.endswith('.png'):
-                item_data['media-type'] = 'image/png'
-            elif filename.endswith('.jpg'):
-                item_data['media-type'] = 'image/jpeg'
-
-            if filename == 'nav.xhtml':
-                items.insert(0, E.item(item_data))
-            else:
-                items.append(E.item(item_data))
-
-    em = ElementMaker(
-        namespace='http://www.idpf.org/2007/opf',
-        nsmap={
-            None: 'http://www.idpf.org/2007/opf',
-            'dc': 'http://purl.org/dc/elements/1.1/'})
-    dc = ElementMaker(
-        namespace='http://purl.org/dc/elements/1.1/',
-        nsmap={
-            'dc': 'http://purl.org/dc/elements/1.1/'})
-
-    book_identifier = 'book-' + unique_id
-    package_content = em.package(
-        {
-            'version': '3.0',
-            'dir': 'ltr',
-            'unique-identifier': book_identifier
-        },
-        em.metadata(
-            dc.identifier(
-                {'id': book_identifier},
-                f"urn:uuid:{unique_id}"
-            ),
-            dc.title(
-                config.get('title')
-            ),
-            dc.language(
-                'en-US'
-            ),
-            dc.creator(
-                config.get('author')
-            ),
-            em.meta(
-                {'property': 'dcterms:modified'},
-                datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
-            )
-        ),
-        em.manifest(*items),
-        em.spine(*spines)
-    )
-
-    package_file_path = path.join(getcwd(), 'build/content/source.opf')
-    with open(package_file_path, 'wb') as package_file:
-        package_file.write(et.tostring(package_content, pretty_print=True))
-
-    console.info(f"Wrote OPF package file {bold}{package_file_path}{reset}")
-
-
-def _write_mimetype():
-    content_file_path = path.join(getcwd(), 'build/mimetype')
-    with open(content_file_path, 'wb') as content_file:
-        content = 'application/epub+zip'
-        content_file.write(content.encode('ascii'))
-
-    console.info(f"Wrote media type identification {bold}{content_file_path}{reset}")

--- a/nonja/cli.py
+++ b/nonja/cli.py
@@ -1,34 +1,51 @@
-from sys import argv
+from argparse import ArgumentParser
 
-from nonja.style import reset, blue
-from nonja.info import version, print_usage
+from nonja.info import version
 from nonja.server import run as run_server
 from nonja.scaffold import scaffold_project
 from nonja.builder import build_project, rebuild_project
 from nonja.generator import generate_content
 from nonja.observer import watch_project
+from nonja.migrator import migrate_content
 
 def main():
-    print(f"{blue}Nonja SSG{reset} for Python v{version}")
-    print('Docs available from https://nonja.intriguedeviation.com')
-    print('')
+    parser = ArgumentParser(description=f"Nonja SSG for Python v{version}")
+    subparsers = parser.add_subparsers(dest="command", required=False)
     
-    if len(argv) == 1:
-        print_usage()
-        exit(0)
+    subparsers.add_parser("init-web", help="Initializes a new web project", aliases=["iw", "i"])
+    subparsers.add_parser("init-epub", help="Initializes a new EPUB project", aliases=["ib"])
+    subparsers.add_parser("serve-proj", help="Launches a local web server for the build content.", aliases=["s"])
+    subparsers.add_parser("build", help="Builds the current project content.", aliases=["b"])
+    
+    gen_parser = subparsers.add_parser("generate", help="Generates a scaffold for project content.", aliases=["g"])
+    gen_parser.add_argument("type", action="store", choices=["page", "template", "style", "drawing", "data", "markdown", "project-file"])
+    gen_parser.add_argument("name", action="store")
+    gen_parser.add_argument("options", action="store", nargs="?", default="")
+    
+    subparsers.add_parser("watch", help="Starts a watcher process to rebuild the project content when files change.", aliases=["w"])
+    
+    subparsers.add_parser("upgrade", help="Upgrades a prior project format to this version of Nonja.")
 
-    command = argv[1]
-    if command == 'serve':
-        run_server()
-    elif command == 'init':
-        args = argv[2:] if len(argv) >= 3 else argv[1:]
-        scaffold_project(*args)
-    elif command == 'build' or command == 'b':
-        build_project()
-    elif command == 'rebuild' or command == 'rb':
-        rebuild_project()
-    elif command == 'generate' or command == 'g':
-        generate_content(*argv[2:])
-    elif command == 'watch' or command == 'w':
-        watch_project()
+    try:
+        args = parser.parse_args()
 
+        if args.command == "init-web" or args.command == "iw" or args.command == "i":
+            scaffold_project(type="web")
+        elif args.command == "init-epub" or args.command == "ib":
+            scaffold_project(type="book")
+        elif args.command == "serve-proj" or args.command == "s":
+            run_server()
+        elif args.command == "build" or args.command == "b":
+            build_project()
+        elif args.command == "generate" or args.command == "g":
+            generate_content(*[
+                args.type,
+                args.name,
+                args.options
+            ])
+        elif args.command == "watch" or args.command == "w":
+            watch_project()
+        elif args.command == "upgrade":
+            migrate_content()
+    except Exception as e:
+        print(e)

--- a/nonja/cli.py
+++ b/nonja/cli.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 from nonja.info import version
 from nonja.server import run as run_server
 from nonja.scaffold import scaffold_project
-from nonja.builder import build_project, rebuild_project
+from nonja.builder import build_project
 from nonja.generator import generate_content
 from nonja.observer import watch_project
 from nonja.migrator import migrate_content
@@ -15,7 +15,9 @@ def main():
     subparsers.add_parser("init-web", help="Initializes a new web project", aliases=["iw", "i"])
     subparsers.add_parser("init-epub", help="Initializes a new EPUB project", aliases=["ib"])
     subparsers.add_parser("serve-proj", help="Launches a local web server for the build content.", aliases=["s"])
-    subparsers.add_parser("build", help="Builds the current project content.", aliases=["b"])
+
+    build_parser = subparsers.add_parser("build", help="Builds the current project content.", aliases=["b"])
+    build_parser.add_argument("--include-assets", action="store_true")
     
     gen_parser = subparsers.add_parser("generate", help="Generates a scaffold for project content.", aliases=["g"])
     gen_parser.add_argument("type", action="store", choices=["page", "template", "style", "drawing", "data", "markdown", "project-file"])
@@ -36,7 +38,9 @@ def main():
         elif args.command == "serve-proj" or args.command == "s":
             run_server()
         elif args.command == "build" or args.command == "b":
-            build_project()
+            build_project(**{
+                "include-assets": args.include_assets
+            })
         elif args.command == "generate" or args.command == "g":
             generate_content(*[
                 args.type,

--- a/nonja/generator.py
+++ b/nonja/generator.py
@@ -34,12 +34,15 @@ def generate_content(*args):
 
 
 def _generate_page(filename, template_name='shared'):
+    if len(template_name) == 0:
+        template_name = 'shared'
+
     console.debug(
         f"Page generation requested for page {bold}{filename}{reset} with template {bold}{template_name}{reset}")
 
-    page_content = '{%' + f" extends '_{template_name}.html' " + '%}' + _page_default
+    page_content = '{%' + f" extends '_{template_name}.j2' " + '%}' + _page_default
 
-    page_path = path.join(getcwd(), f"src/content/{filename}.html")
+    page_path = path.join(getcwd(), f"src/content/{filename}.j2")
     page_folder_path = path.dirname(page_path)
     if not path.exists(page_folder_path):
         makedirs(page_folder_path, exist_ok=True)
@@ -48,7 +51,7 @@ def _generate_page(filename, template_name='shared'):
     with open(page_path, 'wb') as page_file:
         page_file.write(page_content.encode())
 
-    template_file_path = path.join(getcwd(), f"src/content/_{template_name}.html")
+    template_file_path = path.join(getcwd(), f"src/content/_{template_name}.j2")
     if not path.exists(template_file_path):
         _generate_template(template_name)
 
@@ -73,7 +76,7 @@ def _generate_template(template_name):
     config = _get_project_config()
     content = _template_default if config.get('projectType', 'web') == 'web' else _book_template_default
 
-    template_file_path = path.join(getcwd(), f"src/content/_{template_name}.html")
+    template_file_path = path.join(getcwd(), f"src/content/_{template_name}.j2")
     with open(template_file_path, 'wb') as template_file:
         template_file.write(content.encode())
 

--- a/nonja/info.py
+++ b/nonja/info.py
@@ -1,13 +1,13 @@
 from nonja.style import bold, reset
 
-version = '0.1.5-dev'
+version = '0.1.6-dev'
 
-
-def print_usage():
-    print(f"  {bold}init{reset}        Generates the necessary structure and basic components for a project.")
-    print(f"  {bold}generate{reset}    Also {bold}g{reset}; generates an asset for the project.")
+# TODO: Remove if useless
+# def print_usage():
+#     print(f"  {bold}init{reset}        Generates the necessary structure and basic components for a project.")
+#     print(f"  {bold}generate{reset}    Also {bold}g{reset}; generates an asset for the project.")
         
-    print('')
-    print(f"  {bold}build{reset}       Also {bold}b{reset}; combines the content and template files for output.")
-    print(f"  {bold}serve{reset}       Serves the contents of the build folder.")
+#     print('')
+#     print(f"  {bold}build{reset}       Also {bold}b{reset}; combines the content and template files for output.")
+#     print(f"  {bold}serve{reset}       Serves the contents of the build folder.")
 

--- a/nonja/migrator.py
+++ b/nonja/migrator.py
@@ -14,19 +14,18 @@ def migrate_content():
 
     console.info(f"Beginning migration of {bold}HTML{reset} to {bold}J2{reset}.")
 
+    conv_count = 0
+
     for root, _, files in walk(content_folder):
         for file in files:
             if not file.endswith(source_extension):
                 continue
-        
-            console.debug(f"\tFound file {bold}{file}{reset}.")
 
             source_file_path = path.join(root, file)
             target_file_name = file.replace(source_extension, target_extension)
             output_file_path = path.join(root, target_file_name)
 
             if path.exists(output_file_path):
-                console.info(f"\tTarget {bold}{output_file_path}{reset} exists, skipping.")
                 continue
             else:
                 with open(source_file_path, 'rb') as source_file:
@@ -34,5 +33,9 @@ def migrate_content():
                     with open(output_file_path, 'wb') as target_file:
                         target_file.write(source_file_content)
 
-                console.info(f"\tMigrated {bold}{file}{reset} to J2.")
                 unlink(source_file_path)
+
+                conv_count += 1
+    
+    console.info(f"Migration complete: converted {conv_count} HTML files to J2 templates.")
+    console.warn("You will need to update the contents of the pages and templates to reference the correct file names before building.")

--- a/nonja/migrator.py
+++ b/nonja/migrator.py
@@ -1,0 +1,38 @@
+"""Migration module for updating from prior versions of the tool."""
+
+from os import path, getcwd, walk, unlink
+
+from nonja.style import bold, reset
+import nonja.console as console
+
+
+def migrate_content():
+    content_path = "./src/content"
+    content_folder = path.join(getcwd(), content_path)
+    source_extension = ".html"
+    target_extension = ".j2"
+
+    console.info(f"Beginning migration of {bold}HTML{reset} to {bold}J2{reset}.")
+
+    for root, _, files in walk(content_folder):
+        for file in files:
+            if not file.endswith(source_extension):
+                continue
+        
+            console.debug(f"\tFound file {bold}{file}{reset}.")
+
+            source_file_path = path.join(root, file)
+            target_file_name = file.replace(source_extension, target_extension)
+            output_file_path = path.join(root, target_file_name)
+
+            if path.exists(output_file_path):
+                console.info(f"\tTarget {bold}{output_file_path}{reset} exists, skipping.")
+                continue
+            else:
+                with open(source_file_path, 'rb') as source_file:
+                    source_file_content = source_file.read()
+                    with open(output_file_path, 'wb') as target_file:
+                        target_file.write(source_file_content)
+
+                console.info(f"\tMigrated {bold}{file}{reset} to J2.")
+                unlink(source_file_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nonja"
-version = "0.1.5-dev"
+version = "0.1.6-dev"
 description = "A static site generator using Python, Jinja2, SASS, and other tools."
 readme = "README.md"
 requires-python = ">= 3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "Jinja2",
     "lxml",
     "pyyaml",
-    "markdown"
+    "markdown",
+    "pillow"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ six>=1.16.0
 soupsieve>=2.5
 tomli>=2.0.1
 webencodings>=0.5.1
+pillow>=11.1.0


### PR DESCRIPTION
Updates the following:

* Image and SVG assets are transferred in the build process via the `--include-assets` argument
* Image assets are automatically converted to WEBP format from JPG and PNG
* New command structure from `argparse` package:
  * `init-web` for starting new web projects; shortcuts are `iw` and `i`
  * `init-epub` for starting HTML-based ePUB builds (not fully implemented)
  * `serve-proj` for running a local project server; shortcut `s`
  * `build` for building the current project; shortcut `b`
  * `watch` for running a file watcher on the current project for changes to content; shortcut `w`
  * `upgrade` for migrating projects built with 0.1.5 or earlier to the new format (use with caution)
